### PR TITLE
Update tests for repository changes

### DIFF
--- a/MyApi.Tests/Controllers/GroupsControllerTests.cs
+++ b/MyApi.Tests/Controllers/GroupsControllerTests.cs
@@ -81,7 +81,7 @@ namespace MyApi.Tests.Controllers
             var traderId = 123;
             var entityList = new List<WhitelistedGroup>
                 {
-                    new WhitelistedGroup { Id = "W1", GroupName = "Whitelist One", TraderId = traderId }
+                    new WhitelistedGroup { Id = "W1", GroupName = "Whitelist One" }
                 };
 
             // Note: service returns List<WhitelistedGroups>, not List<GroupDto>
@@ -177,7 +177,7 @@ namespace MyApi.Tests.Controllers
         public async Task DeWhitelistGroupId_ReturnsOk_WhenServiceSucceeds()
         {
             // Arrange
-            var traderId = "42";
+            var traderId = 42;
             var groupId = "G300";
             _groupServiceMock
                 .Setup(s => s.DeleteWhitelistedGroup(traderId, groupId))
@@ -195,7 +195,7 @@ namespace MyApi.Tests.Controllers
         public async Task DeWhitelistGroupId_ReturnsBadRequest_WhenServiceThrows()
         {
             // Arrange
-            var traderId = "84";
+            var traderId = 84;
             var groupId = "G400";
             var exceptionMessage = "Cannot delete";
             _groupServiceMock

--- a/MyApi.Tests/Services/DistributeAdServiceTests.cs
+++ b/MyApi.Tests/Services/DistributeAdServiceTests.cs
@@ -79,7 +79,7 @@ namespace MyApi.Tests.Services
             var groupRepo = new Mock<IGroupRepository>();
             groupRepo
                 .Setup(r => r.GetWhitelistedGroups(traderId))
-                .ReturnsAsync(new[]
+                .ReturnsAsync(new List<WhitelistedGroup>
                 {
                     new WhitelistedGroup { Id = "G1" },
                     new WhitelistedGroup { Id = "G2" }
@@ -88,7 +88,7 @@ namespace MyApi.Tests.Services
             var adRepo = new Mock<IAdRepository>();
             adRepo
                 .Setup(r => r.CreateAd(It.IsAny<Ad>()))
-                .Returns(Task.CompletedTask);
+                .ReturnsAsync(new Ad());
 
             var service = new DistributeAdService(
                 strategies,
@@ -146,10 +146,10 @@ namespace MyApi.Tests.Services
             var groupRepo = new Mock<IGroupRepository>();
             groupRepo
                 .Setup(r => r.GetWhitelistedGroups(traderId))
-                .ReturnsAsync(new[] { new WhitelistedGroup { Id = "G1" } });
+                .ReturnsAsync(new List<WhitelistedGroup> { new WhitelistedGroup { Id = "G1" } });
 
             var adRepo = new Mock<IAdRepository>();
-            adRepo.Setup(r => r.CreateAd(It.IsAny<Ad>())).Returns(Task.CompletedTask);
+            adRepo.Setup(r => r.CreateAd(It.IsAny<Ad>())).ReturnsAsync(new Ad());
 
             var service = new DistributeAdService(
                 strategies,
@@ -213,14 +213,14 @@ namespace MyApi.Tests.Services
             var groupRepo = new Mock<IGroupRepository>();
             groupRepo
                 .Setup(r => r.GetWhitelistedGroups(traderId))
-                .ReturnsAsync(new[]
+                .ReturnsAsync(new List<WhitelistedGroup>
                 {
                     new WhitelistedGroup { Id = "G1" },
                     new WhitelistedGroup { Id = "G2" }
                 });
 
             var adRepo = new Mock<IAdRepository>();
-            adRepo.Setup(r => r.CreateAd(It.IsAny<Ad>())).Returns(Task.CompletedTask);
+            adRepo.Setup(r => r.CreateAd(It.IsAny<Ad>())).ReturnsAsync(new Ad());
 
             var service = new DistributeAdService(
                 strategies,
@@ -287,10 +287,10 @@ namespace MyApi.Tests.Services
             var groupRepo = new Mock<IGroupRepository>();
             groupRepo
                 .Setup(r => r.GetWhitelistedGroups(traderId))
-                .ReturnsAsync(new[] { new WhitelistedGroup { Id = "G1" } });
+                .ReturnsAsync(new List<WhitelistedGroup> { new WhitelistedGroup { Id = "G1" } });
 
             var adRepo = new Mock<IAdRepository>();
-            adRepo.Setup(r => r.CreateAd(It.IsAny<Ad>())).Returns(Task.CompletedTask);
+            adRepo.Setup(r => r.CreateAd(It.IsAny<Ad>())).ReturnsAsync(new Ad());
 
             var service = new DistributeAdService(
                 strategies,

--- a/MyApi.Tests/Services/GroupServiceTests.cs
+++ b/MyApi.Tests/Services/GroupServiceTests.cs
@@ -53,8 +53,8 @@ namespace MyApi.Tests.Services
             int traderId = 5;
             var whitelisted = new List<WhitelistedGroup>
             {
-                new WhitelistedGroup { Id = "W1", GroupName = "WhiteOne", TraderId = traderId },
-                new WhitelistedGroup { Id = "W2", GroupName = "WhiteTwo", TraderId = traderId }
+                new WhitelistedGroup { Id = "W1", GroupName = "WhiteOne" },
+                new WhitelistedGroup { Id = "W2", GroupName = "WhiteTwo" }
             };
 
             _groupRepoMock
@@ -70,42 +70,40 @@ namespace MyApi.Tests.Services
         }
 
         [Fact]
-        public async Task DeleteWhitelistedGroup_CallsRepository_WithHardCodedTraderId()
+        public async Task DeleteWhitelistedGroup_ForwardsTraderIdToRepository()
         {
             // Arrange
-            string bearerToken = "jwt-token"; // ignored by implementation
+            int traderId = 2;
             string groupId = "G1";
 
-            // NOTE: repository.DeleteWhitelistedGroup returns Task, so we use Task.CompletedTask
             _groupRepoMock
-                .Setup(r => r.DeleteWhitelistedGroup(2, groupId))
+                .Setup(r => r.DeleteWhitelistedGroup(traderId, groupId))
                 .Returns(Task.CompletedTask);
 
             // Act
-            await _service.DeleteWhitelistedGroup(bearerToken, groupId);
+            await _service.DeleteWhitelistedGroup(traderId, groupId);
 
-            // Assert: verify that DeleteWhitelistedGroup(2, groupId) was indeed called once
-            _groupRepoMock.Verify(r => r.DeleteWhitelistedGroup(2, groupId), Times.Once);
+            // Assert: verify that the same trader id was used
+            _groupRepoMock.Verify(r => r.DeleteWhitelistedGroup(traderId, groupId), Times.Once);
         }
 
         [Fact]
-        public async Task WhitelistGroup_CallsRepository_WithHardCodedTraderId()
+        public async Task WhitelistGroup_ForwardsTraderIdToRepository()
         {
             // Arrange
-            int traderId = 99; // ignored by implementation
+            int traderId = 99;
             string groupId = "G3";
             string groupName = "GroupThree";
 
-            // repository.WhitelistGroup also returns Task, so again use Task.CompletedTask
             _groupRepoMock
-                .Setup(r => r.WhitelistGroup(2, groupId, groupName))
+                .Setup(r => r.WhitelistGroup(traderId, groupId, groupName))
                 .Returns(Task.CompletedTask);
 
             // Act
             await _service.WhitelistGroup(traderId, groupId, groupName);
 
             // Assert
-            _groupRepoMock.Verify(r => r.WhitelistGroup(2, groupId, groupName), Times.Once);
+            _groupRepoMock.Verify(r => r.WhitelistGroup(traderId, groupId, groupName), Times.Once);
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix group service tests after domain updates
- adjust groups controller whitelisted group mocks
- return Ad entities from DistributeAd service tests

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848d555643483288010c95887c84e19