### PR TITLE
Fix service tests

### DIFF
--- a/MyApi.Tests/Services/DistributeAdServiceTests.cs
+++ b/MyApi.Tests/Services/DistributeAdServiceTests.cs
@@ -169,7 +169,8 @@ namespace MyApi.Tests.Services
             // Arrange
             var traderId = 7;
             var bearerToken = "tok";
-            var imageBytes = Encoding.UTF8.GetBytes("fake-image-bytes");
+            var imageBytes = Convert.FromBase64String(
+                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/wcAAwAB/6fkdwAAAABJRU5ErkJggg==");
             var formFile = CreateMockFormFile("pic.png", "image/png", imageBytes);
 
             var dto = new DistributeAdDto
@@ -263,7 +264,8 @@ namespace MyApi.Tests.Services
             // Arrange
             var traderId = 13;
             var bearerToken = "bt";
-            var bytes = Encoding.UTF8.GetBytes("x");
+            var bytes = Convert.FromBase64String(
+                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/wcAAwAB/6fkdwAAAABJRU5ErkJggg==");
             var formFile = CreateMockFormFile("i.jpg", "image/jpeg", bytes);
 
             var dto = new DistributeAdDto

--- a/MyApi.Tests/Services/TriggerCheckerServiceTests.cs
+++ b/MyApi.Tests/Services/TriggerCheckerServiceTests.cs
@@ -32,7 +32,7 @@ namespace MyApi.Tests.Services
 
             // 3) Create and register a Mock<INotification>
             _notificationMock = new Mock<INotification>();
-            services.AddSingleton(_notificationMock.Object);
+            services.AddSingleton<INotification>(_notificationMock.Object);
 
             // 4) Build the provider
             _serviceProvider = services.BuildServiceProvider();
@@ -92,7 +92,8 @@ namespace MyApi.Tests.Services
 
             _notificationMock
                 .Setup(n => n.SendNotification(It.IsAny<SendEmailRequest>()))
-                .Callback(() => tcs.TrySetResult(true));
+                .Callback(() => tcs.TrySetResult(true))
+                .Returns(Task.CompletedTask);
 
             // Use a CancellationTokenSource that we will cancel manually
             var cts = new CancellationTokenSource();
@@ -152,7 +153,8 @@ namespace MyApi.Tests.Services
             var tcs = new TaskCompletionSource<bool>();
             _notificationMock
                 .Setup(n => n.SendNotification(It.IsAny<SendEmailRequest>()))
-                .Callback(() => tcs.TrySetResult(true));
+                .Callback(() => tcs.TrySetResult(true))
+                .Returns(Task.CompletedTask);
 
             var cts = new CancellationTokenSource();
 


### PR DESCRIPTION
## Summary
- update DI registration for INotification in TriggerCheckerService tests
- return completed task from SendNotification mocks
- use valid base64 image data for DistributeAdService image tests

## Testing
- `dotnet test MyApi.Tests/MyApi.Tests.csproj --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849386fe3388328afaa91069abc081d